### PR TITLE
Adjusted range of the 'for' loop in plot_week()

### DIFF
--- a/roster_management_clean.ipynb
+++ b/roster_management_clean.ipynb
@@ -196,7 +196,7 @@
     "    tmlist, tmticks, tmbold = [], [], []\n",
     "\n",
     "    cury = 0\n",
-    "    for g in d['schedule'][:nummatchups]:\n",
+    "    for g in d['schedule'][week * nummatchups - nummatchups:week * nummatchups]:\n",
     "        aid, anm = -1, ''\n",
     "        hid, hnm = -1, ''\n",
     "        try:\n",


### PR DESCRIPTION
Used slice notation to adjust the starting and ending point of the 'for' loop that iterates through all the matchups in d['schedule']. Before, the loop began at index 0 and ended after iterating through 'nummatchups' times. Now the loop will start at an index determined by what week matchups you're looking for.